### PR TITLE
Added additional checks for fpin events.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ OBJS	= $(SRCS:.c=.o)
 LIB	= -lpthread -ludev -ldevmapper -lmpathcmd
 
 
-CFLAGS += -g
+CFLAGS += -g -DFPIN_DEBUG
 TARGET	= fctxpd
 
 $(TARGET): $(OBJS)

--- a/README
+++ b/README
@@ -43,8 +43,26 @@ Steps performed during daemon execution:
 	point 4, is parsed to get the sd* and dm-* information. A list of sd* which
 	are to be failed is populated here. 
 
-7.	Finally, the list populated above is used to fail the path using multipath
-	libraries.
+7.	Finally, the list populated above is used to set the path to marginal
+	using multipath	libraries.
+
+8.	Once the link integrity issues are fixed ,user needs to do port toggling
+	i.e port disable and port enable to transition the marginal paths to normal.
+
+9.	On receving the LINKUP/RSCN events, the daemon will set the marginal paths associated
+	with host number to normal.
+
+10.	User can run the below command to check the status of a path
+		multipathd show paths format "%d %t %M" .
+
+	The sample o/p is below
+
+	dev dm_st  marginal_st
+	sda undef  normal
+	sdb active normal
+	sdc active marginal
+
+
 
 Steps to compile:
 Please install udev,pthread ,devmapper libraries before we start compiling.

--- a/fpin.h
+++ b/fpin.h
@@ -53,6 +53,9 @@
 #define UUID_LEN		128
 #define FILE_PATH_LEN	576		// SYS_PATH_LEN + Filename
 #define DEV_STATUS_LEN	64
+#define FCH_EVT_LINKUP 0x2
+#define FCH_EVT_LINK_FPIN 0x501
+#define FCH_EVT_RSCN 0x5
 
 struct impacted_devs
 {
@@ -90,12 +93,19 @@ struct wwn_list
 	uint32_t host_num;
 	struct list_head impacted_ports_wwn_head;
 };
+/* Structure to store the marginal devices info */
+struct marginal_dev_list
+{
+	char dev_name[DEV_NAME_LEN];
+	uint32_t host_num;
+	struct list_head marginal_dev_list_head;
+};
 
 /* ELS frame Handling functions */
 int fpin_fetch_dm_lun_data(struct wwn_list *list,
 			struct list_head *dm_list_head,
 			struct list_head *impacted_dev_list_head, struct udev *udev);
-void fpin_dm_fail_path(struct list_head *dm_list_head,
+void fpin_dm_marginal_path(uint32_t host_num, struct list_head *dm_list_head,
 				struct list_head *impacted_dev_list_head);
 
 int fpin_populate_dm_lun(struct list_head *dm_list_head,
@@ -115,5 +125,7 @@ void fpin_free_dm(struct list_head *dm_head);
 /* WWN Related Functions */
 int fpin_els_wwn_exists(struct wwn_list *list, const char *port_wwn_buf);
 void fpin_els_free_wwn_list(struct wwn_list *list);
+void fpin_unset_marginal_dev(uint32_t host_num, struct list_head *tgt_head);
 
+extern struct list_head fpin_li_marginal_dev_list_head;
 #endif

--- a/fpin_els.h
+++ b/fpin_els.h
@@ -11,10 +11,8 @@
 /* max ELS frame Size */
 #define FC_PAYLOAD_MAXLEN   2048
 #define SYS_PATH_LEN		512
-/* ELS Frame, TBD: Use FPIN ELS once standardized */
+
 #define ELS_CMD_FPIN 0x16
-#define ELS_CMD_MPD 0x82
-#define ELS_CMD_CJN 0x83
 
 #define MARGINAL_CHECKER_WAIT_TIME 30
 
@@ -35,11 +33,6 @@ struct els_marginal_list {
 	struct list_head els_frame;
 };
 
-struct marginal_dev_list {
-	char dev_sys_path[SYS_PATH_LEN];
-	time_t dev_log_time;
-	struct list_head dev_list_head;
-};
 
 /* --- FPIN --- */
 


### PR DESCRIPTION
Incorporated the review comments by Benjamin.

Enabled debug logs in Makefile

Made changes in the code to set path to marginal instead of
fail path.

Added additional checks for the FPIN events and ignore the other
events which are not supported at present with the log.

Added changes to unset the marginal paths on receving
LINKUP and RSCN events

Updated the README doc accordingly